### PR TITLE
remove unnecessary waiting when pxeboot fails

### DIFF
--- a/pxeboot
+++ b/pxeboot
@@ -258,7 +258,14 @@ def bf_select_pxe_entry(args):
         print(f"Found boot interface after {30 - retry} tries, sending enter")
         child.send(KEY_ENTER)
         time.sleep(1)
-        max_tries = 20
+        print(f"Waiting 30 seconds for Station IP address prompt")
+        try:
+            child.expect("Station IP address.*", timeout=30)
+        except Exception:
+            e = Exception("Kernel boot failed to begin")
+            print(e)
+            raise e
+        max_tries = 10
         total_time = max_tries * 30
         print(f"Waiting {total_time} sec for EFI stub message")
         found, tries = False, 0
@@ -406,7 +413,7 @@ def try_pxy_boot():
     else:
         bf_select_pxe_entry(args)
 
-    response_ip = wait_any_ping(list(f"172.31.100.{x}" for x in range(10, 21)), 300)
+    response_ip = wait_any_ping(list(f"172.31.100.{x}" for x in range(10, 21)), 180)
     print(f"got response from {response_ip}")
     if args.key:
         ipa = wait_and_login(args, response_ip)


### PR DESCRIPTION
In the instances we have not found the ETI stub message or have not been able to successfully ping the bf by a certain point, waiting longer does not seem to result in success. It would seem the issue is not timing out, but rather something that has already gone wrong with the boot / race condition with DHCP.

In the case of looking for the ETI stub message when pxe-booting, there will be early output we can detect prior to the ETF stub message which shows the pxe-boot is progressing ("Station IP address *"). In the event we don't see this output, the pxeboot has already failed, so we can bail out earlier and retry to reduce the time spent waiting.