### PR TITLE
fix get_mode

### DIFF
--- a/get_mode
+++ b/get_mode
@@ -9,6 +9,8 @@ def main():
     parser.add_argument('-v', '--verbose', dest='verbose',
                         default=False, action='store', type=bool,
                         help='Enable verbose output. This will show the settings')
+    parser.add_argument('-n', '--next_boot', action='store_true',
+                        help='Get the next_boot mode of the BF')
     args = parser.parse_args()
 
     bf = common_bf.find_bf_pci_addresses_or_quit(args.id)
@@ -21,7 +23,7 @@ def main():
         "INTERNAL_CPU_OFFLOAD_ENGINE"
     ]
     all_cfg = " ".join(cfg)
-    ret = common_bf.run(f"mstconfig -d {bf} q {all_cfg}").out
+    ret = common_bf.run(f"mstconfig -e -d {bf} q {all_cfg}").out
 
     save_next = False
     settings = {}
@@ -31,8 +33,12 @@ def main():
         if e.startswith("Configurations:"):
             save_next = True
         elif save_next:
-            k, v = e.split()
-            settings[k] = v.split("(")[1].split(")")[0]
+            if "different from default/current" in e:
+                save_next = False
+                continue
+            k, default, current, next_boot = e.lstrip('*').split()
+            config = next_boot if args.next_boot else current
+            settings[k] = config.split("(")[1].split(")")[0]
 
     dpu_mode = {
         'INTERNAL_CPU_MODEL': '1',


### PR DESCRIPTION
get_mode currently gets the next_boot state by default, instead we should use the current_state unless otherwise specified