### PR TITLE
[th/cleanup-shebang] all: use same shebang for python3 tools

### DIFF
--- a/cx_fwup
+++ b/cx_fwup
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import os, sys
 

--- a/fwdefaults
+++ b/fwdefaults
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, sys
 import common_bf

--- a/fwup
+++ b/fwup
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import sys
 import requests

--- a/fwversion
+++ b/fwversion
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import common_bf
 import argparse


### PR DESCRIPTION
Consistently use the same shebang in scripts.

- the common place for env is /usr/bin/env

- use python3 instead of python. On Fedora/CentOS, the unversioned
  python binary requires the python-unversioned-command package.