### PR TITLE
[th/reformat-black] black: reformat all code with python black

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,25 @@
+name: Check style, test
+
+on:
+  push:
+    branches:
+  pull_request:
+    branches:
+
+jobs:
+  check3_9:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install black
+    - name: Check code formatting with Black
+      run: |
+       black --version
+       black --check --diff .

--- a/bfb
+++ b/bfb
@@ -7,8 +7,18 @@ import time
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Downloads BFB images and sends it to the BF.')
-    parser.add_argument('-i', '--id', dest='id', default=0, action='store', type=int, help='Specify the id of the BF.')
+    parser = argparse.ArgumentParser(
+        description="Downloads BFB images and sends it to the BF."
+    )
+    parser.add_argument(
+        "-i",
+        "--id",
+        dest="id",
+        default=0,
+        action="store",
+        type=int,
+        help="Specify the id of the BF.",
+    )
     args = parser.parse_args()
     _ = common_bf.find_bf_pci_addresses_or_quit(args.id)
 

--- a/common_bf.py
+++ b/common_bf.py
@@ -16,6 +16,7 @@ def run(cmd: str, env: dict = os.environ.copy()):
         ret = proc.returncode
     return Result(out, err, ret)
 
+
 def all_interfaces():
     out = run("lshw -c network -businfo").out
     ret = {}
@@ -25,14 +26,16 @@ def all_interfaces():
             continue
         pci, dev = e.split()[0:2]
         before_network = e.split("network")[0].strip()
-        desc = e[len(before_network):].strip()[len("network"):].strip()
+        desc = e[len(before_network) :].strip()[len("network") :].strip()
         ret[pci] = desc
     return ret
+
 
 def find_bf_pci_addresses():
     ai = all_interfaces()
     bfs = [e for e in ai.items() if "BlueField" in e[1]]
     return [k.split("@")[1] for k, v in bfs]
+
 
 def find_bf_pci_addresses_or_quit(bf_id):
     bf_pci = find_bf_pci_addresses()
@@ -43,6 +46,7 @@ def find_bf_pci_addresses_or_quit(bf_id):
         print("Invalid ID for BF")
         sys.exit(-1)
     return bf_pci[bf_id]
+
 
 def mst_flint(pci):
     out = run(f"mstflint -d {pci} q").out
@@ -60,6 +64,7 @@ def mst_flint(pci):
         value = value.strip()
         ret[key] = value
     return ret
+
 
 def bf_version(pci):
     out = run("lshw -c network -businfo").out

--- a/console
+++ b/console
@@ -6,11 +6,23 @@ import argparse
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Select BF to connect to with a console.')
-    parser.add_argument('-i', '--id', dest='id', default=0, action='store', type=int, help='Specify the id of the BF.')
+    parser = argparse.ArgumentParser(
+        description="Select BF to connect to with a console."
+    )
+    parser.add_argument(
+        "-i",
+        "--id",
+        dest="id",
+        default=0,
+        action="store",
+        type=int,
+        help="Specify the id of the BF.",
+    )
     args = parser.parse_args()
     _ = common_bf.find_bf_pci_addresses_or_quit(args.id)
-    os.system(f"minicom --color on --baudrate 115200 --device /dev/rshim{args.id//2}/console")
+    os.system(
+        f"minicom --color on --baudrate 115200 --device /dev/rshim{args.id//2}/console"
+    )
 
 
 if __name__ == "__main__":

--- a/cx_fwup
+++ b/cx_fwup
@@ -2,6 +2,7 @@
 
 import os, sys
 
+
 def main():
     os.system("chmod +x mlxup")
     r = os.system("/mlxup -y")

--- a/dpu-tools/dpu-tools
+++ b/dpu-tools/dpu-tools
@@ -42,7 +42,7 @@ def console(args):
         backed_up = False
         temp_file_path = ""
 
-    with open(minirc_path, 'w') as new_file:
+    with open(minirc_path, "w") as new_file:
         new_file.write("pu rtscts           No\n")
     os.system(minicom_cmd)
 
@@ -52,9 +52,9 @@ def console(args):
 
 def find_bus_pci_address(address: str) -> str:
     pattern = r"(\d+):(\d+)\.(\d+)"
-    
+
     match = re.match(pattern, address)
-    
+
     if match:
         bus = match.group(1)
         device = match.group(2)
@@ -81,26 +81,28 @@ def list_dpus(args):
     print("-----  --------  ------------  ------")
     for i, (k, (d, kind)) in enumerate(devs.items()):
         print(f"{i: 5d}  {k.ljust(8)}  {d.ljust(12)}  {kind}")
-            
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Tools to interact with an IPU')
-    subparsers = parser.add_subparsers(title='subcommands', description='Valid subcommands', dest='subcommand')
+    parser = argparse.ArgumentParser(description="Tools to interact with an IPU")
+    subparsers = parser.add_subparsers(
+        title="subcommands", description="Valid subcommands", dest="subcommand"
+    )
 
-    reset_parser = subparsers.add_parser('reset', help='Reset the IPU')
+    reset_parser = subparsers.add_parser("reset", help="Reset the IPU")
     reset_parser.set_defaults(func=reset)
 
-    list_parser = subparsers.add_parser('list', help='list devices')
+    list_parser = subparsers.add_parser("list", help="list devices")
     list_parser.set_defaults(func=list_dpus)
 
-    console_parser = subparsers.add_parser('console', help='Open console for the IPU')
+    console_parser = subparsers.add_parser("console", help="Open console for the IPU")
     console_parser.set_defaults(func=console)
-    console_parser.add_argument('target', choices=['imc', 'acc'], help="Specify imc or acc as the target")
-
+    console_parser.add_argument(
+        "target", choices=["imc", "acc"], help="Specify imc or acc as the target"
+    )
 
     args = parser.parse_args()
-    if hasattr(args, 'func'):
+    if hasattr(args, "func"):
         args.func(args)
     else:
         parser.print_help()
@@ -108,5 +110,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-

--- a/fwdefaults
+++ b/fwdefaults
@@ -4,12 +4,24 @@ import os, sys
 import common_bf
 import argparse
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Resets the firmware settings on the BF to defaults.')
-    parser.add_argument('-i', '--id', dest='id', default=0, action='store', type=int, help='Specify the id of the BF.')
+    parser = argparse.ArgumentParser(
+        description="Resets the firmware settings on the BF to defaults."
+    )
+    parser.add_argument(
+        "-i",
+        "--id",
+        dest="id",
+        default=0,
+        action="store",
+        type=int,
+        help="Specify the id of the BF.",
+    )
     args = parser.parse_args()
     bf = common_bf.find_bf_pci_addresses_or_quit(args.id)
     os.system(f"mstconfig -y -d {bf} r")
+
 
 if __name__ == "__main__":
     main()

--- a/fwup
+++ b/fwup
@@ -11,14 +11,16 @@ class RemoteAPI:
         self._remote_url = f"https://downloaders.azurewebsites.net/downloaders/bluefield{bf_version}_fw_downloader/helper.php"
 
     def get_latest_version(self):
-        data = {'action': 'get_versions', }
+        data = {
+            "action": "get_versions",
+        }
         response = requests.post(self._remote_url, data=data)
         return response.json()["latest"]
 
     def get_distros(self, v):
         data = {
-          'action': 'get_distros',
-          'version': v,
+            "action": "get_distros",
+            "version": v,
         }
         r = requests.post(self._remote_url, data=data)
 
@@ -26,20 +28,20 @@ class RemoteAPI:
 
     def get_os(self, version, distro):
         data = {
-          'action': 'get_oses',
-          'version': version,
-          'distro': distro,
+            "action": "get_oses",
+            "version": version,
+            "distro": distro,
         }
         r = requests.post(self._remote_url, data=data)
         return r.json()[0]
 
     def get_download_info(self, version, distro, os_param):
         data = {
-          'action': 'get_download_info',
-          'version': version,
-          'distro': distro,
-          'os': os_param,
-          'arch': 'x64'
+            "action": "get_download_info",
+            "version": version,
+            "distro": distro,
+            "os": os_param,
+            "arch": "x64",
         }
         r = requests.post(self._remote_url, data=data)
         return r.json()
@@ -89,9 +91,27 @@ def update_bf_firmware(args):
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Specify the id of the BF. Updates the firmware on the BF to the latest avaible one.')
-    parser.add_argument('-i', '--id', dest='id', default=0, action='store', type=int, help='Specify the id of the BF.')
-    parser.add_argument('-v','--version', dest='version', default='', action='store', type=str, help='specify a specific firmware version to install (i.e. 24.35.1012)')
+    parser = argparse.ArgumentParser(
+        description="Specify the id of the BF. Updates the firmware on the BF to the latest avaible one."
+    )
+    parser.add_argument(
+        "-i",
+        "--id",
+        dest="id",
+        default=0,
+        action="store",
+        type=int,
+        help="Specify the id of the BF.",
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        dest="version",
+        default="",
+        action="store",
+        type=str,
+        help="specify a specific firmware version to install (i.e. 24.35.1012)",
+    )
     args = parser.parse_args()
     r = update_bf_firmware(args)
     sys.exit(r)

--- a/fwversion
+++ b/fwversion
@@ -3,12 +3,22 @@
 import common_bf
 import argparse
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Shows firmware version.')
-    parser.add_argument('-i', '--id', dest='id', default=0, action='store', type=int, help='Specify the id of the BF-2.')
+    parser = argparse.ArgumentParser(description="Shows firmware version.")
+    parser.add_argument(
+        "-i",
+        "--id",
+        dest="id",
+        default=0,
+        action="store",
+        type=int,
+        help="Specify the id of the BF-2.",
+    )
     args = parser.parse_args()
     bf = common_bf.find_bf_pci_addresses_or_quit(args.id)
     print(common_bf.mst_flint(bf)["FW Version"])
+
 
 if __name__ == "__main__":
     main()

--- a/get_mode
+++ b/get_mode
@@ -2,15 +2,33 @@
 import common_bf
 import argparse
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Reads the current mode of the BF.')
-    parser.add_argument('-i', '--id', dest='id', default=0,
-                        action='store', type=int, help='Specify the id of the BF.')
-    parser.add_argument('-v', '--verbose', dest='verbose',
-                        default=False, action='store', type=bool,
-                        help='Enable verbose output. This will show the settings')
-    parser.add_argument('-n', '--next_boot', action='store_true',
-                        help='Get the next_boot mode of the BF')
+    parser = argparse.ArgumentParser(description="Reads the current mode of the BF.")
+    parser.add_argument(
+        "-i",
+        "--id",
+        dest="id",
+        default=0,
+        action="store",
+        type=int,
+        help="Specify the id of the BF.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="verbose",
+        default=False,
+        action="store",
+        type=bool,
+        help="Enable verbose output. This will show the settings",
+    )
+    parser.add_argument(
+        "-n",
+        "--next_boot",
+        action="store_true",
+        help="Get the next_boot mode of the BF",
+    )
     args = parser.parse_args()
 
     bf = common_bf.find_bf_pci_addresses_or_quit(args.id)
@@ -20,7 +38,7 @@ def main():
         "INTERNAL_CPU_PAGE_SUPPLIER",
         "INTERNAL_CPU_ESWITCH_MANAGER",
         "INTERNAL_CPU_IB_VPORT0",
-        "INTERNAL_CPU_OFFLOAD_ENGINE"
+        "INTERNAL_CPU_OFFLOAD_ENGINE",
     ]
     all_cfg = " ".join(cfg)
     ret = common_bf.run(f"mstconfig -e -d {bf} q {all_cfg}").out
@@ -36,23 +54,25 @@ def main():
             if "different from default/current" in e:
                 save_next = False
                 continue
-            k, default, current, next_boot = e.lstrip('*').split()
+            k, default, current, next_boot = e.lstrip("*").split()
             config = next_boot if args.next_boot else current
             settings[k] = config.split("(")[1].split(")")[0]
 
     dpu_mode = {
-        'INTERNAL_CPU_MODEL': '1',
-        'INTERNAL_CPU_PAGE_SUPPLIER': '0',
-        'INTERNAL_CPU_ESWITCH_MANAGER': '0',
-        'INTERNAL_CPU_IB_VPORT0': '0',
-        'INTERNAL_CPU_OFFLOAD_ENGINE': '0'}
+        "INTERNAL_CPU_MODEL": "1",
+        "INTERNAL_CPU_PAGE_SUPPLIER": "0",
+        "INTERNAL_CPU_ESWITCH_MANAGER": "0",
+        "INTERNAL_CPU_IB_VPORT0": "0",
+        "INTERNAL_CPU_OFFLOAD_ENGINE": "0",
+    }
 
     nic_mode = {
-        'INTERNAL_CPU_MODEL': '1',
-        'INTERNAL_CPU_PAGE_SUPPLIER': '1',
-        'INTERNAL_CPU_ESWITCH_MANAGER': '1',
-        'INTERNAL_CPU_IB_VPORT0': '1',
-        'INTERNAL_CPU_OFFLOAD_ENGINE': '1'}
+        "INTERNAL_CPU_MODEL": "1",
+        "INTERNAL_CPU_PAGE_SUPPLIER": "1",
+        "INTERNAL_CPU_ESWITCH_MANAGER": "1",
+        "INTERNAL_CPU_IB_VPORT0": "1",
+        "INTERNAL_CPU_OFFLOAD_ENGINE": "1",
+    }
 
     if dpu_mode == settings:
         print("dpu")
@@ -62,6 +82,7 @@ def main():
         print("unknown")
     if args.verbose:
         print(settings)
+
 
 if __name__ == "__main__":
     main()

--- a/listbf
+++ b/listbf
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 import common_bf
 
+
 def main():
     bf2s = common_bf.find_bf_pci_addresses()
     print("ID     PCI-Address")
     print("-----  ------------")
-    for (i, e) in enumerate(bf2s):
+    for i, e in enumerate(bf2s):
         print(f"{i: 5d}  {e}")
+
 
 if __name__ == "__main__":
     main()

--- a/pxeboot
+++ b/pxeboot
@@ -55,17 +55,45 @@ def read_file(fn):
 
 def read_args():
     url = "http://download.eng.brq.redhat.com/released/rhel-9/RHEL-9/9.2.0/BaseOS/aarch64/os/images/efiboot.img"
-    parser = argparse.ArgumentParser(description='Set up a PXE server on a specific port.')
-    parser.add_argument('iso', metavar='iso', type=str, help='iso to use for PXE booting')
-    parser.add_argument("-e",  metavar='efiboot_img', dest='efiboot_img', default=url, type=str, help='Specify url to pull efiboot from.')
-    parser.add_argument("-m",  '--wait-minicom', dest='wait_minicom', default=False, action='store_true', help='Instead of running minicom to select pxe entry, just wait indefinitely.')
+    parser = argparse.ArgumentParser(
+        description="Set up a PXE server on a specific port."
+    )
+    parser.add_argument(
+        "iso", metavar="iso", type=str, help="iso to use for PXE booting"
+    )
+    parser.add_argument(
+        "-e",
+        metavar="efiboot_img",
+        dest="efiboot_img",
+        default=url,
+        type=str,
+        help="Specify url to pull efiboot from.",
+    )
+    parser.add_argument(
+        "-m",
+        "--wait-minicom",
+        dest="wait_minicom",
+        default=False,
+        action="store_true",
+        help="Instead of running minicom to select pxe entry, just wait indefinitely.",
+    )
     help = (
         "if key is specified, the script will log in to the BF and"
-        " run \'ip --json a\' before quitting. This also means that the"
+        " run 'ip --json a' before quitting. This also means that the"
         " script will only block when the BF has booted"
     )
-    parser.add_argument("-w",  metavar='key', dest='key', default='', type=str, help=help)
-    parser.add_argument('-i', '--id', dest='id', default=0, action='store', type=int, help='Specify the id of the BF.')
+    parser.add_argument(
+        "-w", metavar="key", dest="key", default="", type=str, help=help
+    )
+    parser.add_argument(
+        "-i",
+        "--id",
+        dest="id",
+        default=0,
+        action="store",
+        type=int,
+        help="Specify the id of the BF.",
+    )
 
     args = parser.parse_args()
     args.ip = "172.31.100.1"
@@ -173,12 +201,9 @@ def prepare_pxe(args):
     time.sleep(10)
     args.is_coreos = os.path.exists("/var/ftp/mnt/coreos")
 
-    print(f'{os_name(args.is_coreos)} detected')
+    print(f"{os_name(args.is_coreos)} detected")
 
-    rhel_files = [
-        "BOOTAA64.EFI",
-        "grubaa64.efi",
-        "mmaa64.efi"]
+    rhel_files = ["BOOTAA64.EFI", "grubaa64.efi", "mmaa64.efi"]
 
     if not all(map(os.path.exists, rhel_files)):
         if not os.path.exists("efiboot.img"):
@@ -195,9 +220,7 @@ def prepare_pxe(args):
         for file in rhel_files:
             shutil.copy(f"{mount_path}/EFI/BOOT/{file}", "/var/lib/tftpboot/")
 
-    ftp_files = [
-        "images/pxeboot/vmlinuz",
-        "images/pxeboot/initrd.img"]
+    ftp_files = ["images/pxeboot/vmlinuz", "images/pxeboot/initrd.img"]
 
     if args.is_coreos:
         ftp_files.append("images/ignition.img")
@@ -217,7 +240,7 @@ def prepare_pxe(args):
 
 
 def minicom_cmd(args):
-    return f'minicom --baudrate 115200 --device {rshim_base(args)}/console'
+    return f"minicom --baudrate 115200 --device {rshim_base(args)}/console"
 
 
 def pexpect_child_wait(child, pattern, timeout):
@@ -246,8 +269,8 @@ def pexpect_child_wait(child, pattern, timeout):
 def bf_select_pxe_entry(args):
     print("selecting pxe entry in bf")
     ESC = "\x1b"
-    KEY_DOWN = '\x1b[B'
-    KEY_ENTER = '\r\n'
+    KEY_DOWN = "\x1b[B"
+    KEY_ENTER = "\r\n"
 
     common_bf.run("pkill -9 minicom")
     print("spawn minicom")
@@ -256,7 +279,7 @@ def bf_select_pxe_entry(args):
     print("waiting for instructions to enter UEFI Menu to interrupt and go to bios")
     pexpect_child_wait(child, "Press.* enter UEFI Menu.", 120)
     print("found UEFI prompt, sending 'esc'")
-    child.send(ESC*10)
+    child.send(ESC * 10)
     time.sleep(1)
     child.close()
     print("respawning minicom")
@@ -266,7 +289,10 @@ def bf_select_pxe_entry(args):
     child.send(KEY_DOWN)
     time.sleep(1)
     print("waiting on language option")
-    child.expect("This is the option.*one adjusts to change.*the language for the.*current system", timeout=3)
+    child.expect(
+        "This is the option.*one adjusts to change.*the language for the.*current system",
+        timeout=3,
+    )
     print("pressing down again")
     child.send(KEY_DOWN)
     print("waiting for Boot manager entry")
@@ -327,7 +353,7 @@ def run(cmd):
 
 def http_server():
     os.chdir("/www")
-    server_address = ('', 80)
+    server_address = ("", 80)
     handler = http.server.SimpleHTTPRequestHandler
     httpd = http.server.HTTPServer(server_address, handler)
     httpd.serve_forever()
@@ -365,7 +391,7 @@ def wait_and_login(args, ip):
             host = paramiko.SSHClient()
             host.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             pkey = get_private_key(key)
-            host.connect(ip, username='core', pkey=pkey)
+            host.connect(ip, username="core", pkey=pkey)
             break
         except paramiko.ssh_exception.NoValidConnectionsError as e:
             print(f"Unable to establish SSH connection: {e}")
@@ -401,14 +427,14 @@ def prepare_kickstart(ip):
 
     shutil.copy(f"/{ks}", dst)
 
-    with open(dst, 'r') as file:
+    with open(dst, "r") as file:
         file_content = file.read()
 
     find_text = "NETWORK_INSTALL_URL"
     replace_text = f"http://{ip}/mnt"
     updated_content = file_content.replace(find_text, replace_text)
 
-    with open(dst, 'w') as file:
+    with open(dst, "w") as file:
         file.write(updated_content)
 
 
@@ -474,7 +500,9 @@ def try_pxy_boot():
 
     stop_event = threading.Event()
     output = []
-    minicom_watch = threading.Thread(target=capture_minicom, args=(args, stop_event, output))
+    minicom_watch = threading.Thread(
+        target=capture_minicom, args=(args, stop_event, output)
+    )
     minicom_watch.start()
 
     ping_exception = None
@@ -485,11 +513,11 @@ def try_pxy_boot():
     except Exception as e:
         ping_exception = e
         # keep linter happy
-        response_ip = ''
+        response_ip = ""
     stop_event.set()
     minicom_watch.join()
-    output = b''.join(output)
-    output_str = output.decode('utf-8', errors='replace')
+    output = b"".join(output)
+    output_str = output.decode("utf-8", errors="replace")
     print(output_str)
     if ping_exception is not None:
         raise ping_exception
@@ -508,16 +536,16 @@ def try_pxy_boot():
 
 
 def kill_existing():
-    pids = [pid for pid in os.listdir('/proc') if pid.isdigit()]
+    pids = [pid for pid in os.listdir("/proc") if pid.isdigit()]
 
     own_pid = os.getpid()
     for pid in filter(lambda x: int(x) != own_pid, pids):
         try:
-            with open(os.path.join('/proc', pid, 'cmdline'), 'rb') as f:
+            with open(os.path.join("/proc", pid, "cmdline"), "rb") as f:
                 # print(f.read().decode("utf-8"))
-                zb = b'\x00'
+                zb = b"\x00"
                 cmd = [x.decode("utf-8") for x in f.read().strip(zb).split(zb)]
-                if (cmd[0] == 'python3' and os.path.basename(cmd[1]) == 'pxeboot'):
+                if cmd[0] == "python3" and os.path.basename(cmd[1]) == "pxeboot":
                     print(f"Killing pid {pid}")
                     os.kill(int(pid), signal.SIGKILL)
         except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.black]
+include = '''
+    (
+        \.py$
+        | ^/bfb$
+        | ^/console$
+        | ^/cx_fwup$
+        | ^/dpu-tools/dpu-tools$
+        | ^/fwdefaults$
+        | ^/fwup$
+        | ^/fwversion$
+        | ^/get_mode$
+        | ^/listbf$
+        | ^/pxeboot$
+        | ^/reset$
+        | ^/set_mode$
+    )
+    '''

--- a/reset
+++ b/reset
@@ -3,13 +3,23 @@
 import common_bf
 import argparse
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Reboots the BF.')
-    parser.add_argument('-i', '--id', dest='id', default=0, action='store', type=int, help='Specify the id of the BF.')
+    parser = argparse.ArgumentParser(description="Reboots the BF.")
+    parser.add_argument(
+        "-i",
+        "--id",
+        dest="id",
+        default=0,
+        action="store",
+        type=int,
+        help="Specify the id of the BF.",
+    )
     args = parser.parse_args()
     bf_pci = common_bf.find_bf_pci_addresses_or_quit(args.id)
     with open(f"/dev/rshim{args.id//2}/misc", "w") as f:
         f.write("SW_RESET 1")
+
 
 if __name__ == "__main__":
     main()

--- a/set_mode
+++ b/set_mode
@@ -3,32 +3,45 @@ import common_bf
 import os
 import argparse
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Reads the current mode of the BF-2.')
-    parser.add_argument('mode', metavar='mode', type=str, help='which mode to set the BF-2 to.')
-    parser.add_argument('-i', '--id', dest='id', default=0, action='store', type=int, help='Specify the id of the BF-2.')
+    parser = argparse.ArgumentParser(description="Reads the current mode of the BF-2.")
+    parser.add_argument(
+        "mode", metavar="mode", type=str, help="which mode to set the BF-2 to."
+    )
+    parser.add_argument(
+        "-i",
+        "--id",
+        dest="id",
+        default=0,
+        action="store",
+        type=int,
+        help="Specify the id of the BF-2.",
+    )
     args = parser.parse_args()
 
     bf = common_bf.find_bf_pci_addresses_or_quit(args.id)
 
     dpu_mode = {
-        'INTERNAL_CPU_MODEL': 'EMBEDDED_CPU(1)',
-        'INTERNAL_CPU_PAGE_SUPPLIER': 'ECPF(0)',
-        'INTERNAL_CPU_ESWITCH_MANAGER': 'ECPF(0)',
-        'INTERNAL_CPU_IB_VPORT0': 'ECPF(0)',
-        'INTERNAL_CPU_OFFLOAD_ENGINE': 'ENABLED(0)'}
+        "INTERNAL_CPU_MODEL": "EMBEDDED_CPU(1)",
+        "INTERNAL_CPU_PAGE_SUPPLIER": "ECPF(0)",
+        "INTERNAL_CPU_ESWITCH_MANAGER": "ECPF(0)",
+        "INTERNAL_CPU_IB_VPORT0": "ECPF(0)",
+        "INTERNAL_CPU_OFFLOAD_ENGINE": "ENABLED(0)",
+    }
 
     nic_mode = {
-        'INTERNAL_CPU_MODEL': 'EMBEDDED_CPU(1)',
-        'INTERNAL_CPU_PAGE_SUPPLIER': 'ECPF(1)',
-        'INTERNAL_CPU_ESWITCH_MANAGER': 'ECPF(1)',
-        'INTERNAL_CPU_IB_VPORT0': 'ECPF(1)',
-        'INTERNAL_CPU_OFFLOAD_ENGINE': 'ENABLED(1)'}
+        "INTERNAL_CPU_MODEL": "EMBEDDED_CPU(1)",
+        "INTERNAL_CPU_PAGE_SUPPLIER": "ECPF(1)",
+        "INTERNAL_CPU_ESWITCH_MANAGER": "ECPF(1)",
+        "INTERNAL_CPU_IB_VPORT0": "ECPF(1)",
+        "INTERNAL_CPU_OFFLOAD_ENGINE": "ENABLED(1)",
+    }
 
     settings = dpu_mode if args.mode == "dpu" else nic_mode
 
     joined = ""
-    for (k, v) in settings.items():
+    for k, v in settings.items():
         value = v[-3:].strip("()")
         joined += f"{k}={value} "
     cmd = f"mstconfig -y -d {bf} s {joined}"


### PR DESCRIPTION
- add a .github test for checking the formatting.

- for python scripts without extension, we must list the filenames in pyproject.toml.

- the version of black used for reformatting was 24.4.2. But 22.12.0 produces the same output.