### PR TITLE
refactor logger

### DIFF
--- a/dpu-tools
+++ b/dpu-tools
@@ -4,7 +4,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 import argparse
 import sys
-import logging
+from logger import logger, setup_logging
 from typing import Optional
 from utils.fwutils import BFFirmware, IPUFirmware, cx_fwup
 from utils.common_ipu import (
@@ -18,12 +18,9 @@ from utils.common import (
     DPUType,
     detect_dpu_type,
     scan_for_dpus,
-    setup_logging,
     run,
 )
 from utils.pxeboot import Pxeboot
-
-logger = logging.getLogger(__name__)
 
 
 class DPUTools(ABC):
@@ -69,9 +66,6 @@ class DPUTools(ABC):
         print("-----  --------  ------------  ------")
         for i, (k, (d, kind)) in enumerate(devs.items()):
             print(f"{i: 5d}  {k.ljust(8)}  {d.ljust(12)}  {kind}")
-
-    def setup_logging(self) -> None:
-        setup_logging(self.args.verbose)
 
     def setup_arguments(self, parser: argparse.ArgumentParser) -> argparse.Namespace:
         """Add common arguments and subcommands."""
@@ -300,11 +294,11 @@ class IPUTools(DPUTools):
         fw.reflash_ipu()
 
     def firmware_reset(self) -> None:
-        result = get_current_version(self.args.imc_address, logger=logger)
+        result = get_current_version(self.args.imc_address)
         if result.returncode:
-            logger.debug("Failed with ssh, trying minicom!")
+            logger.info("Failed with ssh, trying minicom!")
             try:
-                minicom_get_version(logger=logger)
+                minicom_get_version()
             except Exception as e:
                 logger.error(f"Error ssh try: {result.err}")
                 logger.error(f"Exception with minicom: {e}")
@@ -320,11 +314,11 @@ class IPUTools(DPUTools):
         fw.reflash_ipu()
 
     def firmware_version(self) -> None:
-        result = get_current_version(self.args.imc_address, logger=logger)
+        result = get_current_version(self.args.imc_address)
         if result.returncode:
-            logger.debug("Failed with ssh, trying minicom!")
+            logger.info("Failed with ssh, trying minicom!")
             try:
-                minicom_get_version(logger=logger)
+                minicom_get_version()
             except Exception as e:
                 logger.error(f"Error ssh try: {result.err}")
                 logger.error(f"Exception with minicom: {e}")
@@ -385,13 +379,13 @@ def main() -> None:
     dpu_type = known_args.dpu_type
     # Step 2: Detect DPU type if --dpu-type is not provided
     if dpu_type is None:
-        logger.debug(f"Dpu_type was not given, detecting it...")
+        logger.info(f"Dpu_type was not given, detecting it...")
         detected = detect_dpu_type()
         if detected.returncode != 0:
-            logging.error(f"Couldn't detect DPU type: {detected.err}")
+            logger.error(f"Couldn't detect DPU type: {detected.err}")
             sys.exit(detected.returncode)
         dpu_type = detected.out.upper()
-        logger.debug(f"Detected dpu_type: {dpu_type}")
+        logger.info(f"Detected dpu_type: {dpu_type}")
     else:
         dpu_type = dpu_type.upper()
 
@@ -405,7 +399,7 @@ def main() -> None:
         exit(1)
     assert dpu_tools is not None
 
-    dpu_tools.setup_logging()
+    setup_logging(dpu_tools.args.verbose)
     dpu_tools.dispatch()
 
 

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,23 @@
+import logging
+import sys
+
+
+def setup_logging(verbose: bool = False) -> None:
+    log_level = logging.DEBUG if verbose else logging.INFO
+
+    # Clear existing handlers to prevent duplicates
+    for handler in logging.root.handlers[:]:
+        logging.root.removeHandler(handler)
+
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[
+            logging.StreamHandler(sys.stdout),
+        ],
+    )
+
+
+setup_logging(verbose=False)
+
+logger = logging.getLogger(__name__)

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,8 +1,7 @@
 import subprocess
-import logging
+from logger import logger
 from typing import IO
 import requests
-import sys
 import tarfile
 import os
 import re
@@ -23,24 +22,6 @@ class Result:
     out: str
     err: str
     returncode: int
-
-
-def setup_logging(verbose: bool) -> None:
-    if verbose:
-        log_level = logging.DEBUG
-    else:
-        log_level = logging.INFO
-
-    logging.basicConfig(
-        level=log_level,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        handlers=[
-            logging.StreamHandler(sys.stdout),  # Log to stdout
-        ],
-    )
-
-
-logger = logging.getLogger(__name__)
 
 
 def run(command: str, capture_output: bool = True, dry_run: bool = False) -> Result:

--- a/utils/common_bf.py
+++ b/utils/common_bf.py
@@ -1,5 +1,5 @@
 import dataclasses
-import logging
+from logger import logger
 import os
 import sys
 import argparse
@@ -14,9 +14,6 @@ class Result:
     out: str
     err: str
     returncode: int
-
-
-logger = logging.getLogger(__name__)
 
 
 def all_interfaces() -> dict[str, str]:

--- a/utils/common_ipu.py
+++ b/utils/common_ipu.py
@@ -1,4 +1,4 @@
-import logging
+from logger import logger
 import os
 import re
 import pexpect
@@ -8,8 +8,6 @@ from utils.minicom import configure_minicom, pexpect_child_wait, minicom_cmd
 from utils.common import Result, run
 
 VERSIONS = ["1.2.0.7550", "1.6.2.9418", "1.8.0.10052"]
-
-logger = logging.getLogger(__name__)
 
 
 def find_image(
@@ -27,9 +25,7 @@ def find_image(
     )
 
 
-def get_current_version(
-    imc_address: str, logger: logging.Logger, dry_run: bool = False
-) -> Result:
+def get_current_version(imc_address: str, dry_run: bool = False) -> Result:
     logger.debug("Getting Version via SSH")
     version = ""
     # Execute the commands over SSH with dry_run handling
@@ -49,7 +45,7 @@ def get_current_version(
     return Result(version, result.err, result.returncode)
 
 
-def minicom_get_version(logger: logging.Logger) -> str:
+def minicom_get_version() -> str:
     version = ""
     run("pkill -9 minicom")
     logger.debug("Configuring minicom")

--- a/utils/minicom.py
+++ b/utils/minicom.py
@@ -3,11 +3,9 @@ import pexpect
 import os
 import shutil
 import tempfile
-import logging
+from logger import logger
 from contextlib import contextmanager
 from typing import Generator
-
-logger = logging.getLogger(__name__)
 
 
 def minicom_cmd(dpu_type: str) -> str:


### PR DESCRIPTION
Previously, we would invoke logger before initilizing it, which was a bug.

Additionally, we had multiple instances of logger spread out throughout the code. It seems cleaner to define this once, and provide a single method to update the verbosity.